### PR TITLE
Use binary mode when open a file

### DIFF
--- a/lib/fluent/plugin/out_file_sprintf.rb
+++ b/lib/fluent/plugin/out_file_sprintf.rb
@@ -85,7 +85,7 @@ module Fluent
 
       filename_hash = {}
       set.each do|prefix|
-        filename_hash[prefix] = File.open(@path + '.' + prefix, 'a')
+        filename_hash[prefix] = File.open(@path + '.' + prefix, 'ab')
       end
 
       chunk.msgpack_each do |tag, time, record|
@@ -100,7 +100,7 @@ module Fluent
     end
 
     def write_file_no_rotate(chunk)
-      file = File.open(@path, 'a')
+      file = File.open(@path, 'ab')
       chunk.msgpack_each do |tag, time, record|
         result = eval(@eval_string)
         file.puts result


### PR DESCRIPTION
In Fluentd 0.14.0 (Stable version is not released yet), it supports Windows platform.
On Windows, file reading will finish at 0x1A (EOF).
We should use `binary mode` instead.