### PR TITLE
Adding "require 'fluent/formatter'"

### DIFF
--- a/lib/fluent/plugin/out_file_sprintf.rb
+++ b/lib/fluent/plugin/out_file_sprintf.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+require 'fluent/formatter'
+
 module Fluent
   class FileSprintfOutput < Fluent::TimeSlicedOutput
     Fluent::Plugin.register_output('file_sprintf', self)


### PR DESCRIPTION
This change is required for this plugin to work with recent versions of fluentd.

Similar issue on another plugin:
https://github.com/fluent/fluentd/issues/911